### PR TITLE
Added support for SF 3.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "require": {
         "php": ">=5.4.0",
         "portphp/portphp": "^1.0@dev",
-        "symfony/console": "~2.5"
+        "symfony/console": "~2.5|~3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Hi there,

I've changed the `symfony/console` version constraint to support 3.0+ as well.

Cheers,

Robin