### PR TITLE
Fixed: Package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Open a command console, enter your project directory and execute the
 following command to download the latest stable version of this package:
 
 ```bash
-$ composer require portphp/symfony-console-adapter
+$ composer require portphp/symfony-console
 ```
 
 This command requires you to have Composer installed globally, as explained


### PR DESCRIPTION
`portphp/symfony-console-adapter` -> `portphp/symfony-console`