### PR TITLE
Fix error thrown when rendering with no items

### DIFF
--- a/spec/TableWriterSpec.php
+++ b/spec/TableWriterSpec.php
@@ -38,4 +38,11 @@ class TableWriterSpec extends ObjectBehavior
 
         $this->finish();
     }
+
+    function it_handles_zero_items(Table $table)
+    {
+        $table->setHeaders([])->shouldBeCalled();
+        $table->render()->shouldBeCalled();
+        $this->finish();        
+    }
 }

--- a/src/TableWriter.php
+++ b/src/TableWriter.php
@@ -47,7 +47,8 @@ class TableWriter implements Writer
      * {@inheritdoc}
      */
     public function finish() {
-        $this->table->setHeaders(array_keys($this->firstItem));
+        $headers = $this->firstItem ? array_keys($this->firstItem) : [];
+        $this->table->setHeaders($headers);
         $this->table->render();
 
         $this->firstItem = null;


### PR DESCRIPTION
This may happen when all the items in the pipeline are filtered out or fail validation.

Test added to cover this case